### PR TITLE
Use `vars = {` instead of `vars {` to appease Terraform 0.13

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -4,7 +4,7 @@ data "aws_region" "main" {}
 data "template_file" "main" {
   template = "${file("${path.module}/templates/create_table.sql.tpl")}"
 
-  vars {
+  vars = {
     bucket     = "${var.s3_bucket_name}"
     account_id = "${data.aws_caller_identity.main.account_id}"
     region     = "${data.aws_region.main.name}"


### PR DESCRIPTION
Otherwise this happens:

```
Error: Unsupported block type

  on .terraform/modules/athena_lb_logs/data.tf line 7, in data "template_file" "main":
   7:   vars {

Blocks of type "vars" are not expected here. Did you mean to define argument
"vars"? If so, use the equals sign to assign it a value.
```